### PR TITLE
Add verify to session request argument

### DIFF
--- a/apypie/api.py
+++ b/apypie/api.py
@@ -161,7 +161,9 @@ class Api:
 
     def http_call(self, http_method, path, params=None, headers=None, options=None):
         full_path = urljoin(self.uri, path)
-        kwargs = {}
+        kwargs = {
+            'verify': self._session.verify,
+        }
 
         if headers:
             kwargs['headers'] = headers


### PR DESCRIPTION
Add the `verify` flag to the arguments sent into
`requests.session.request` to ensure that a value of `False` gets
honored even when there are environment variables `REQUESTS_CA_BUNDLE`
or `CURL_CA_BUNDLE` present.