### PR TITLE
place the cache into $XDG_CACHE_HOME by default

### DIFF
--- a/apypie/api.py
+++ b/apypie/api.py
@@ -37,7 +37,15 @@ class Api:
         self.uri = kwargs.get('uri')
         self.api_version = kwargs.get('api_version', 1)
         self.language = kwargs.get('language')
-        apidoc_cache_base_dir = kwargs.get('apidoc_cache_base_dir', os.path.join(os.path.expanduser('~/.cache'), 'apypie'))
+
+        # Find where to put the cache by default according to the XDG spec
+        # Not using just get('XDG_CACHE_HOME', '~/.cache') because the spec says
+        # that the defaut should be used if "$XDG_CACHE_HOME is either not set or empty"
+        xdg_cache_home = os.environ.get('XDG_CACHE_HOME', None)
+        if not xdg_cache_home:
+            xdg_cache_home = '~/.cache'
+
+        apidoc_cache_base_dir = kwargs.get('apidoc_cache_base_dir', os.path.join(os.path.expanduser(xdg_cache_home), 'apypie'))
         self.apidoc_cache_dir = kwargs.get('apidoc_cache_dir', os.path.join(apidoc_cache_base_dir, self.uri.replace(':', '_').replace('/', '_'), 'v{}'.format(self.api_version)))
         self.apidoc_cache_name = kwargs.get('apidoc_cache_name', 'default')
 

--- a/tests/test_apypie.py
+++ b/tests/test_apypie.py
@@ -3,6 +3,7 @@ import pytest
 
 import apypie
 import json
+import os
 
 
 def test_init(api):
@@ -36,6 +37,17 @@ def test_init_with_lang_family(fixture_dir, requests_mock, tmpdir):
         data = json.load(read_file)
     requests_mock.get('https://api.example.com/apidoc/v1.tlh.json', json=data)
     apypie.Api(uri='https://api.example.com', apidoc_cache_dir=tmpdir.strpath, language='tlh_EN')
+
+
+def test_init_with_xdg_cachedir(fixture_dir, requests_mock, tmpdir):
+    with fixture_dir.join('dummy.json').open() as read_file:
+        data = json.load(read_file)
+    requests_mock.get('https://api.example.com/apidoc/v1.json', json=data)
+    old_environ = os.environ.copy()
+    os.environ['XDG_CACHE_HOME'] = tmpdir.strpath
+    apypie.Api(uri='https://api.example.com')
+    os.environ = old_environ
+    assert tmpdir.join('apypie/https___api.example.com/v1/default.json').check(file=1)
 
 
 @pytest.mark.parametrize('username,password,expected', [


### PR DESCRIPTION
Not using just get('XDG_CACHE_HOME', '~/.cache') because the spec says
that the defaut should be used if "$XDG_CACHE_HOME is either not set or empty"