### PR TITLE
accept integers as values for string params

### DIFF
--- a/apypie/action.py
+++ b/apypie/action.py
@@ -83,7 +83,7 @@ class Action:
                         self._validate(param_description.params, value, self._add_to_path(path, param_description.name))
                 if ((param_description.expected_type == 'boolean' and not isinstance(value, bool) and not (isinstance(value, int) and value in [0, 1]))
                         or (param_description.expected_type == 'numeric' and not isinstance(value, int))
-                        or (param_description.expected_type == 'string' and not isinstance(value, basestring))):
+                        or (param_description.expected_type == 'string' and not isinstance(value, (basestring, int)))):
                     raise ValueError(param_description.validator)
 
     def filter_empty_params(self, params=None):

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -129,13 +129,19 @@ def test_action_validate_valid_numeric(api):
 def test_action_validate_invalid_string(resource):
     action = resource.action('create')
     with pytest.raises(ValueError) as excinfo:
-        action.validate({'user': {'name': 1}})
+        action.validate({'user': {'name': []}})
     assert "Must be a String" in str(excinfo.value)
 
 
 def test_action_validate_valid_string(resource):
     action = resource.action('create')
     action.validate({'user': {'name': 'John Doe'}})
+
+
+def test_action_validate_valid_string_as_int(resource):
+    # workaround for https://projects.theforeman.org/issues/27107
+    action = resource.action('create')
+    action.validate({'user': {'name': 1}})
 
 
 def test_action_validate_minimal_correct_params(resource):


### PR DESCRIPTION
int can be safely casted into string, so let's allow that

mostly a workaround for https://projects.theforeman.org/issues/27107