### PR TITLE
allow passing arbitrary kwargs to requests

### DIFF
--- a/apypie/action.py
+++ b/apypie/action.py
@@ -38,8 +38,8 @@ class Action:
     def examples(self):
         return [Example.parse(example) for example in self.apidoc['examples']]
 
-    def call(self, params={}, headers={}, options={}, **kwargs):
-        return self.api.call(self.resource, self.name, params, headers, options, **kwargs)
+    def call(self, params={}, headers={}, options={}, files=None):
+        return self.api.call(self.resource, self.name, params, headers, options, files)
 
     def find_route(self, params=None):
         param_keys = set(self.filter_empty_params(params).keys())

--- a/apypie/action.py
+++ b/apypie/action.py
@@ -38,8 +38,8 @@ class Action:
     def examples(self):
         return [Example.parse(example) for example in self.apidoc['examples']]
 
-    def call(self, params={}, headers={}, options={}):
-        return self.api.call(self.resource, self.name, params, headers, options)
+    def call(self, params={}, headers={}, options={}, **kwargs):
+        return self.api.call(self.resource, self.name, params, headers, options, **kwargs)
 
     def find_route(self, params=None):
         param_keys = set(self.filter_empty_params(params).keys())

--- a/apypie/api.py
+++ b/apypie/api.py
@@ -131,7 +131,7 @@ class Api:
             if not safe:
                 raise
 
-    def call(self, resource_name, action_name, params={}, headers={}, options={}):
+    def call(self, resource_name, action_name, params={}, headers={}, options={}, **kwargs):
         """
         Call an action in the API.
 
@@ -156,22 +156,20 @@ class Api:
         if not options.get('skip_validation', False):
             action.validate(params)
 
-        return self._call_action(action, params, headers, options)
+        return self._call_action(action, params, headers, options, **kwargs)
 
-    def _call_action(self, action, params={}, headers={}, options={}):
+    def _call_action(self, action, params={}, headers={}, options={}, **kwargs):
         route = action.find_route(params)
         get_params = dict((key, value) for key, value in params.items() if key not in route.params_in_path)
         return self.http_call(
             route.method,
             route.path_with_params(params),
             get_params,
-            headers, options)
+            headers, options, **kwargs)
 
-    def http_call(self, http_method, path, params=None, headers=None, options=None):
+    def http_call(self, http_method, path, params=None, headers=None, options=None, **kwargs):
         full_path = urljoin(self.uri, path)
-        kwargs = {
-            'verify': self._session.verify,
-        }
+        kwargs.update({'verify': self._session.verify})
 
         if headers:
             kwargs['headers'] = headers

--- a/apypie/resource.py
+++ b/apypie/resource.py
@@ -26,5 +26,5 @@ class Resource:
     def has_action(self, name):
         return name in self.actions
 
-    def call(self, action, params={}, headers={}, options={}):
-        return self.api.call(self.name, action, params, headers, options)
+    def call(self, action, params={}, headers={}, options={}, **kwargs):
+        return self.api.call(self.name, action, params, headers, options, **kwargs)

--- a/apypie/resource.py
+++ b/apypie/resource.py
@@ -26,5 +26,5 @@ class Resource:
     def has_action(self, name):
         return name in self.actions
 
-    def call(self, action, params={}, headers={}, options={}, **kwargs):
-        return self.api.call(self.name, action, params, headers, options, **kwargs)
+    def call(self, action, params={}, headers={}, options={}, files=None):
+        return self.api.call(self.name, action, params, headers, options, files)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -47,7 +47,7 @@ def test_action_call(resource, mocker):
     headers = {'content-type': 'application/json'}
     mocker.patch('apypie.Api.call', autospec=True)
     assert resource.action('index').call(params, headers)
-    resource.api.call.assert_called_once_with(resource.api, resource.name, 'index', params, headers, {})
+    resource.api.call.assert_called_once_with(resource.api, resource.name, 'index', params, headers, {}, None)
 
 
 def test_action_find_route(resource):

--- a/tests/test_apypie.py
+++ b/tests/test_apypie.py
@@ -81,7 +81,7 @@ def test_call_method(api, mocker):
     headers = {'content-type': 'application/json'}
     mocker.patch('apypie.Api.http_call', autospec=True)
     api.call('users', 'index', params, headers)
-    api.http_call.assert_called_once_with(api, 'get', '/users', params, headers, {})
+    api.http_call.assert_called_once_with(api, 'get', '/users', params, headers, {}, None)
 
 
 def test_call_method_and_skip_validation(api, mocker):
@@ -90,7 +90,7 @@ def test_call_method_and_skip_validation(api, mocker):
     options = {'skip_validation': True}
     mocker.patch('apypie.Api.http_call', autospec=True)
     api.call('users', 'create', params, headers, options)
-    api.http_call.assert_called_once_with(api, 'post', '/users', params, headers, options)
+    api.http_call.assert_called_once_with(api, 'post', '/users', params, headers, options, None)
 
 
 def test_call_method_and_fill_params(api, mocker):
@@ -98,7 +98,7 @@ def test_call_method_and_fill_params(api, mocker):
     headers = {'content-type': 'application/json'}
     mocker.patch('apypie.Api.http_call', autospec=True)
     api.call('users', 'show', params, headers)
-    api.http_call.assert_called_once_with(api, 'get', '/users/1', {}, headers, {})
+    api.http_call.assert_called_once_with(api, 'get', '/users/1', {}, headers, {}, None)
 
 
 def test_http_call_get(api, requests_mock):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -31,13 +31,13 @@ def test_resource_call_action(resource, mocker):
     headers = {'content-type': 'application/json'}
     mocker.patch('apypie.Api.call', autospec=True)
     assert resource.call('index', params, headers)
-    resource.api.call.assert_called_once_with(resource.api, resource.name, 'index', params, headers, {})
+    resource.api.call.assert_called_once_with(resource.api, resource.name, 'index', params, headers, {}, None)
 
 
 def test_resource_call_action_minimal(resource, mocker):
     mocker.patch('apypie.Api.call', autospec=True)
     assert resource.call('index')
-    resource.api.call.assert_called_once_with(resource.api, resource.name, 'index', {}, {}, {})
+    resource.api.call.assert_called_once_with(resource.api, resource.name, 'index', {}, {}, {}, None)
 
 
 def test_resource_existing(resource):


### PR DESCRIPTION
this e.g. allows to do file uploads by passing `files=…` to call()