### PR TITLE
don't pass options to the lower layers of the http calling

### DIFF
--- a/apypie/api.py
+++ b/apypie/api.py
@@ -156,18 +156,18 @@ class Api:
         if not options.get('skip_validation', False):
             action.validate(params)
 
-        return self._call_action(action, params, headers, options, files)
+        return self._call_action(action, params, headers, files)
 
-    def _call_action(self, action, params={}, headers={}, options={}, files=None):
+    def _call_action(self, action, params={}, headers={}, files=None):
         route = action.find_route(params)
         get_params = dict((key, value) for key, value in params.items() if key not in route.params_in_path)
         return self.http_call(
             route.method,
             route.path_with_params(params),
             get_params,
-            headers, options, files)
+            headers, files)
 
-    def http_call(self, http_method, path, params=None, headers=None, options=None, files=None):
+    def http_call(self, http_method, path, params=None, headers=None, files=None):
         full_path = urljoin(self.uri, path)
         kwargs = {
             'verify': self._session.verify,

--- a/tests/test_apypie.py
+++ b/tests/test_apypie.py
@@ -81,7 +81,7 @@ def test_call_method(api, mocker):
     headers = {'content-type': 'application/json'}
     mocker.patch('apypie.Api.http_call', autospec=True)
     api.call('users', 'index', params, headers)
-    api.http_call.assert_called_once_with(api, 'get', '/users', params, headers, {}, None)
+    api.http_call.assert_called_once_with(api, 'get', '/users', params, headers, None)
 
 
 def test_call_method_and_skip_validation(api, mocker):
@@ -90,7 +90,7 @@ def test_call_method_and_skip_validation(api, mocker):
     options = {'skip_validation': True}
     mocker.patch('apypie.Api.http_call', autospec=True)
     api.call('users', 'create', params, headers, options)
-    api.http_call.assert_called_once_with(api, 'post', '/users', params, headers, options, None)
+    api.http_call.assert_called_once_with(api, 'post', '/users', params, headers, None)
 
 
 def test_call_method_and_fill_params(api, mocker):
@@ -98,7 +98,7 @@ def test_call_method_and_fill_params(api, mocker):
     headers = {'content-type': 'application/json'}
     mocker.patch('apypie.Api.http_call', autospec=True)
     api.call('users', 'show', params, headers)
-    api.http_call.assert_called_once_with(api, 'get', '/users/1', {}, headers, {}, None)
+    api.http_call.assert_called_once_with(api, 'get', '/users/1', {}, headers, None)
 
 
 def test_http_call_get(api, requests_mock):


### PR DESCRIPTION
they are only needed for cal() to disable verification