### PR TITLE
fix example parsing regex not to trip older pythons

### DIFF
--- a/apypie/example.py
+++ b/apypie/example.py
@@ -1,7 +1,7 @@
 import re
 
 
-EXAMPLE_PARSER = re.compile(r'(\w+)\s+([^\n]*)\n?(.*)?\n(\d+)\n(.*)', re.DOTALL)
+EXAMPLE_PARSER = re.compile(r'(\w+)\s+([^\n]*)\n?(.*)\n(\d+)\n(.*)', re.DOTALL)
 
 
 class Example:


### PR DESCRIPTION
Fixes: https://github.com/theforeman/foreman-ansible-modules/issues/599