### PR TITLE
don't add empty json to requests that contain data or files

### DIFF
--- a/apypie/api.py
+++ b/apypie/api.py
@@ -211,7 +211,7 @@ class Api:
                 kwargs['params'] = params
             else:
                 kwargs['json'] = params
-        elif http_method in ['post', 'put', 'patch']:
+        elif http_method in ['post', 'put', 'patch'] and not data and not files:
             kwargs['json'] = {}
 
         if files:


### PR DESCRIPTION
requests 2.8.0+ just strips an empty JSON, but 2.6.0 that is in EL7 will
not, which results in bad requests send to Katello/Pulp.

Fixes: https://github.com/theforeman/foreman-ansible-modules/issues/602