### PR TITLE
make mypy ignore basestring being used before definition

### DIFF
--- a/apypie/action.py
+++ b/apypie/action.py
@@ -10,7 +10,7 @@ from apypie.param import Param
 from apypie.exceptions import MissingArgumentsError, InvalidArgumentTypesError
 
 try:
-    basestring  # pylint: disable=used-before-assignment
+    basestring  # type: ignore[used-before-def]  # pylint: disable=used-before-assignment
 except NameError:  # Python 3 has no basestring
     basestring = str  # pylint: disable=invalid-name,redefined-builtin
 


### PR DESCRIPTION
see
https://mypy.readthedocs.io/en/stable/common_issues.html#silencing-linters for the exact syntax needed