### PR TITLE
catch (and re-raise) *any* Exception when retrieving apidoc

### DIFF
--- a/apypie/api.py
+++ b/apypie/api.py
@@ -215,7 +215,7 @@ class Api(object):
         # type: (str, bool) -> Optional[dict]
         try:
             return self.http_call('get', path)
-        except requests.exceptions.HTTPError:
+        except Exception:
             if not safe:
                 raise
             return None


### PR DESCRIPTION
we either don't care which exception prevented the fetch (as we will retry) or will raise it either way (by not cathing it or by re-raising it)