### PR TITLE
Add readthedocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+---
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: requirements-docs.txt


### PR DESCRIPTION
Since September 25, 2023 building without a configuration file is no longer supported: https://blog.readthedocs.com/migrate-configuration-v2/