### PR TITLE
stop catching ImportError after having dropped Python 2 compat

### DIFF
--- a/apypie/action.py
+++ b/apypie/action.py
@@ -4,6 +4,8 @@ Apypie Action module
 
 from __future__ import print_function, absolute_import
 
+from typing import Optional, Any, Iterable, List, TYPE_CHECKING  # pylint: disable=unused-import  # noqa: F401
+
 from apypie.route import Route
 from apypie.example import Example
 from apypie.param import Param
@@ -14,13 +16,8 @@ try:
 except NameError:  # Python 3 has no basestring
     basestring = str  # pylint: disable=invalid-name,redefined-builtin
 
-try:
-    from typing import Optional, Any, Iterable, List, TYPE_CHECKING  # pylint: disable=unused-import
-except ImportError:
-    TYPE_CHECKING = False
-
 if TYPE_CHECKING:
-    from apypie.api import Api  # pylint: disable=cyclic-import,unused-import
+    from apypie.api import Api  # pylint: disable=cyclic-import,unused-import  # noqa: F401
 
 
 class Action(object):

--- a/apypie/api.py
+++ b/apypie/api.py
@@ -21,11 +21,10 @@ import requests
 from apypie.resource import Resource
 from apypie.exceptions import DocLoadingError
 
-try:
-    from typing import Any, Iterable, Optional  # pylint: disable=unused-import
-    from apypie.action import Action  # pylint: disable=unused-import
-except ImportError:
-    pass
+from typing import Any, Iterable, Optional, TYPE_CHECKING  # pylint: disable=unused-import  # noqa: F401
+
+if TYPE_CHECKING:
+    from apypie.action import Action  # pylint: disable=unused-import  # noqa: F401
 
 
 NO_CONTENT = 204

--- a/apypie/api.py
+++ b/apypie/api.py
@@ -7,10 +7,7 @@ from __future__ import print_function, absolute_import
 import errno
 import glob
 import json
-try:
-    from json.decoder import JSONDecodeError  # type: ignore
-except ImportError:
-    JSONDecodeError = ValueError  # type: ignore
+from json.decoder import JSONDecodeError  # type: ignore
 import os
 from urllib.parse import urljoin  # type: ignore
 import requests

--- a/apypie/api.py
+++ b/apypie/api.py
@@ -12,10 +12,7 @@ try:
 except ImportError:
     JSONDecodeError = ValueError  # type: ignore
 import os
-try:
-    from urlparse import urljoin  # type: ignore
-except ImportError:
-    from urllib.parse import urljoin  # type: ignore
+from urllib.parse import urljoin  # type: ignore
 import requests
 
 from apypie.resource import Resource

--- a/apypie/foreman.py
+++ b/apypie/foreman.py
@@ -5,14 +5,11 @@ opinionated helpers to use Apypie with Foreman
 """
 import time
 
-try:
-    from typing import cast, Optional, Set, Tuple
-except ImportError:
-    pass
+from typing import cast, Optional, Set, Tuple
 
 from apypie.api import Api
 
-from apypie.resource import Resource  # pylint: disable=unused-import
+from apypie.resource import Resource  # pylint: disable=unused-import  # noqa: F401
 
 # Foreman supports "per_page=all" since 2.2 (https://projects.theforeman.org/issues/29909)
 # But plugins, especially Katello, do not: https://github.com/Katello/katello/pull/11126

--- a/apypie/inflector.py
+++ b/apypie/inflector.py
@@ -7,10 +7,7 @@ Inflection rules taken from davidcelis's Inflections (https://github.com/davidce
 
 import re
 
-try:
-    from typing import Iterable, Tuple  # pylint: disable=unused-import
-except ImportError:
-    pass
+from typing import Iterable, Tuple  # pylint: disable=unused-import  # noqa: F401
 
 
 class Inflections(object):

--- a/apypie/resource.py
+++ b/apypie/resource.py
@@ -4,15 +4,12 @@ Apypie Resource module
 
 from __future__ import print_function, absolute_import
 
+from typing import Optional, Any, List, TYPE_CHECKING  # pylint: disable=unused-import  # noqa: F401
+
 from apypie.action import Action
 
-try:
-    from typing import Optional, Any, List, TYPE_CHECKING  # pylint: disable=unused-import
-except ImportError:
-    TYPE_CHECKING = False
-
 if TYPE_CHECKING:
-    from apypie.api import Api  # pylint: disable=cyclic-import,unused-import
+    from apypie.api import Api  # pylint: disable=cyclic-import,unused-import  # noqa: F401
 
 
 class Resource(object):

--- a/apypie/route.py
+++ b/apypie/route.py
@@ -9,10 +9,7 @@ try:
 except ImportError:
     from urllib import quote  # type: ignore
 
-try:
-    from typing import List, Optional  # pylint: disable=unused-import
-except ImportError:
-    pass
+from typing import List, Optional  # pylint: disable=unused-import  # noqa: F401
 
 
 class Route(object):

--- a/apypie/route.py
+++ b/apypie/route.py
@@ -4,10 +4,7 @@ Apypie Route module
 
 from __future__ import print_function, absolute_import
 
-try:
-    from urllib.parse import quote  # type: ignore
-except ImportError:
-    from urllib import quote  # type: ignore
+from urllib.parse import quote  # type: ignore
 
 from typing import List, Optional  # pylint: disable=unused-import  # noqa: F401
 


### PR DESCRIPTION
- **stop guarding typing imports, we're Python3-only now**
- **always use urllib.parse, Python2 is no more**
- **always use json.decoder, Python2 is no more**
