### PR TITLE
Fix url query generation when value is a list

### DIFF
--- a/apypie/api.py
+++ b/apypie/api.py
@@ -40,7 +40,7 @@ def _qs_param(param):
 
 
 def _qs_key(k, v):
-    if type(v) in [list, tuple]:
+    if isinstance(v, (list, tuple)):
         return f"{k}[]"
     return k
 

--- a/apypie/api.py
+++ b/apypie/api.py
@@ -39,6 +39,12 @@ def _qs_param(param):
     return param
 
 
+def _qs_key(k, v):
+    if type(v) in [list, tuple]:
+        return f"{k}[]"
+    return k
+
+
 class Api(object):
     """
     Apipie API bindings
@@ -305,7 +311,7 @@ class Api(object):
 
         if params:
             if http_method in ['get', 'head']:
-                kwargs['params'] = {k: _qs_param(v) for k, v in params.items()}
+                kwargs['params'] = {_qs_key(k, v): _qs_param(v) for k, v in params.items()}
             else:
                 kwargs['json'] = params
         elif http_method in ['post', 'put', 'patch'] and not data and not files:

--- a/tests/test_apypie.py
+++ b/tests/test_apypie.py
@@ -240,6 +240,14 @@ def test_http_call_get_with_params(api, requests_mock):
     api.http_call('get', '/', {'test': 'all the things'})
 
 
+def test_http_call_get_with_list_params(api, requests_mock):
+    requests_mock.get('https://api.example.com/?test[]=all&test[]=the&test[]=list', text='{}')
+    api.http_call('get', '/', {'test': ['all', 'the', 'list']})
+
+    requests_mock.get('https://api.example.com/?test[]=all&test[]=the&test[]=tuple', text='{}')
+    api.http_call('get', '/', {'test': ('all', 'the', 'tuple')})
+
+
 def test_http_call_post(api, requests_mock):
     expected_headers = {
         'Accept': 'application/json;version=1',

--- a/tests/test_apypie.py
+++ b/tests/test_apypie.py
@@ -244,6 +244,8 @@ def test_http_call_get_with_list_params(api, requests_mock):
     requests_mock.get('https://api.example.com/?test[]=all&test[]=the&test[]=list', text='{}')
     api.http_call('get', '/', {'test': ['all', 'the', 'list']})
 
+
+def test_http_call_get_with_tuple_params(api, requests_mock):
     requests_mock.get('https://api.example.com/?test[]=all&test[]=the&test[]=tuple', text='{}')
     api.http_call('get', '/', {'test': ('all', 'the', 'tuple')})
 


### PR DESCRIPTION
```python
import apypie

api = apypie.ForemanApi(
        uri="https://foreman.something.somewhere",
        username="admin",
        password="changeme",
        verify_ssl=False,
        )

resource = 'advisor_engine'
action = 'host_details'
params = {"host_uuids": ["1", "2", "3"]}
api.resource_action(resource, action, params)
```

Before the fix, this snippet would result into a path and query like 

```
/api/advisor_engine/host_details?host_uuids=1&host_uuids=2&host_uuids=3
```

When parsed, only the last host_uuid would "win" instead of host_uuids being parsed as a list

After the fix it should be
```
/api/advisor_engine/host_details?host_uuids%5B%5D=1&host_uuids%5B%5D=2&host_uuids%5B%5D=3
```

TODO:
- [x] check what happens if it is a tuple